### PR TITLE
change W3C to WoT

### DIFF
--- a/wot.jsonld
+++ b/wot.jsonld
@@ -1,10 +1,10 @@
 {
     "@context": "http://thingschema.org",
-    "rdfs:label": "W3Cschema",
+    "rdfs:label": "WoTschema",
     "rdfs:resource": [
         {
             "rdf:Class": "WoTinteractionModel",
-            "rdfs:comment": "Base class for W3C Thing Model Interactions",
+            "rdfs:comment": "Base class for WoT Thing Model Interactions",
             "rdfs:subClassOf": "InteractionModel",
             "ts:mayHave": [
                 "thing",
@@ -20,7 +20,7 @@
                 "params"
             ],
             "ts:usedBy": [
-                "W3C_WoT_IG"
+                "WoT"
             ]
         },
         {


### PR DESCRIPTION
Not official W3C activity, so don’t use the org name
